### PR TITLE
Correctly clean up when using subdomains

### DIFF
--- a/src/certbot-dns-namecom.py
+++ b/src/certbot-dns-namecom.py
@@ -104,7 +104,7 @@ if __name__ == '__main__':
 
         for record in j['records']:
             if 'host' in record:
-                if record['host'] == '_acme-challenge':
+                if record['host'].startswith('_acme-challenge') and record['answer'] == certbot_validation:
                     ncd.del_record(record['id'])
 
     if (waitsec != 0):


### PR DESCRIPTION
Subdomains are returned as _acme-challenge.subdomain which was not matching. This also adds a check on the 'answer' in case multiple matches are found.